### PR TITLE
Correction of errors

### DIFF
--- a/nestedbox_core.entity.inc
+++ b/nestedbox_core.entity.inc
@@ -53,7 +53,7 @@ function nestedbox_core_entity_info() {
       // but without the ID suffix. (In fact, you can set
       // entity_operations_entity_uri() as your URI callback, which will use the
       // value here).
-      'path' => 'admin/content/nestedbox',
+      'path' => 'entity_operations_entity_uri',
     ),
   );
 
@@ -77,6 +77,7 @@ function nestedbox_core_entity_info() {
       'label' => 'label',
     ),
     'access callback' => 'nestedbox_type_access',
+    'static cache' => TRUE,
     'module' => 'nestedbox_core',
     // Enable the entity API's admin UI.
     'admin ui' => array(

--- a/nestedbox_type.admin.inc
+++ b/nestedbox_type.admin.inc
@@ -78,3 +78,37 @@ function nestedbox_type_form_submit_delete(&$form, &$form_state) {
   $nestedbox_type = $form_state['nestedbox_type'];
   $form_state['redirect'] = 'admin/structure/nestedbox-types/manage/' . $nestedbox_type->type . '/delete';
 }
+
+/**
+ * Nestedbox type delete form.
+ */
+function nestedbox_type_form_delete_confirm($form, &$form_state, $task_type) {
+  if (!empty($task_type)) {
+    $form_state['task_type'] = $task_type;
+    $form['task_type_id'] = array(
+      '#type' => 'value',
+      '#value' => entity_id('nestedbox_type', $task_type)
+    );
+    return confirm_form($form,
+      t('Are you sure you want to delete task type %title?', array('%title' => entity_label('nestedbox_type', $task_type))),
+      'task/' . entity_id('nestedbox_type', $task_type),
+      t('This action cannot be undone.'),
+      t('Delete'),
+      t('Cancel')
+    );
+  }
+  else {
+    $form_state['redirect'] = 'admin/structure/nestedbox-types';
+  }
+}
+
+/**
+ * Nestedbox type delete form submit handler.
+ */
+function nestedbox_type_form_delete_confirm_submit($form, &$form_state) {
+  $nestedbox_type = $form_state['task_type'];
+  entity_delete('nestedbox_type', entity_id('nestedbox_type' ,$nestedbox_type));
+  watchdog('nestedbox_type', '@type: deleted %title.', array('@type' => $nestedbox_type->type, '%title' => $nestedbox_type->label));
+  drupal_set_message(t('%title has been deleted.', array('%title' => $nestedbox_type->label)));
+  $form_state['redirect'] = 'admin/structure/nestedbox-types';
+}


### PR DESCRIPTION
Discovered and corrected some errors in https://github.com/donquixote/drupal-nestedbox/compare/7.x-1.x...2259005... branch 7.x-1.x-donquixote-local
1 - as you yourself said "There is no more" Add nested box "button on the 'admin / content / nestedbox' page.", There was no "Add nested box", corrected.
2 - at removing such entity published a mistake, because there was no function nestedbox_type_form_delete_confirm, corrected.
